### PR TITLE
Allow nokogiri dependency <= 1.7.2

### DIFF
--- a/twemoji.gemspec
+++ b/twemoji.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = %w(lib)
 
-  spec.add_dependency "nokogiri", [">= 1.4", "<= 1.6.8"]
+  spec.add_dependency "nokogiri", [">= 1.4", "<= 1.7.2"]
 end


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.6.8
Advisory: CVE-2017-5029
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1634
Title: Nokogiri gem contains two upstream vulnerabilities in libxslt 1.1.29
Solution: upgrade to >= 1.7.2

Name: nokogiri
Version: 1.6.8
Advisory: CVE-2016-4658
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1615
Title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
Solution: upgrade to >= 1.7.1
```
